### PR TITLE
docs: update incident response path

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Topic Hash:** 99a8e453b0fd0794
 
 This kit includes:
-- Hardened **SECURITY.md** and **IRP** (`ops/incident_response.md`)
+- Hardened **SECURITY.md** and **IRP** (`incident_response.md`)
 - CI workflow with **SBOM** + **osv-scanner** + **cosign** signing
 - Proprietary **LICENSE**
 - Final MVP Plan (Markdown + HTML) suitable for printing to PDF


### PR DESCRIPTION
## Summary
- fix README link to incident response guide

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'modules')*

------
https://chatgpt.com/codex/tasks/task_e_68b3738d3c788327b44824fb85986fd7